### PR TITLE
Nudge lines with computation closer to O0

### DIFF
--- a/src/dbgcov.ml
+++ b/src/dbgcov.ml
@@ -38,7 +38,7 @@ let () =
                 else Filename.concat (Filename.dirname Sys.executable_name) "dbgcov-tool"
             in
             let the_output_file_name = the_input_file_name ^ ".dbgcov" in
-            let outfd = Unix.openfile the_output_file_name [O_RDWR; O_CREAT] 0o640 in
+            let outfd = Unix.openfile the_output_file_name [O_RDWR; O_CREAT; O_TRUNC] 0o640 in
                ((output_string Pervasives.stderr ("output should go to " ^ the_output_file_name ^ "\n");
                  Pervasives.flush Pervasives.stderr);
                  dup2 outfd stdout);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,6 @@ VAArgExpr
   v(CXXMemberCallExpr) \
   /* v(CastExpr) */ /* too many artificial instances of this */ \
   v(ChooseExpr) \
-  v(FullExpr) \
   v(GenericSelectionExpr) \
   v(LambdaExpr) \
   v(MaterializeTemporaryExpr) \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "clang/Tooling/Tooling.h"
 #include "clang/Tooling/CommonOptionsParser.h" // TODO: remove
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
@@ -123,6 +124,29 @@ VAArgExpr
   STMTS_TO_PRINT(VISITOR_METHOD)
 
   // Some nodes require customised handling depending on the data they contain
+
+  bool VisitFunctionDecl(FunctionDecl *s) {
+    // We want to mark the opening and closing braces as having computation
+    // Debug info associates the function prologue / epilogue with these lines
+    if (const auto *body = dyn_cast_if_present<CompoundStmt>(s->getBody())) {
+      // Prologue
+      body->getBeginLoc().print(llvm::outs(), TheRewriter.getSourceMgr());
+      llvm::outs() << "\t";
+      body->getBeginLoc().print(llvm::outs(), TheRewriter.getSourceMgr());
+      llvm::outs() << "\t";
+      llvm::outs() << "FunctionPrologue";
+      llvm::outs() << "\n";
+
+      // Epilogue
+      body->getEndLoc().print(llvm::outs(), TheRewriter.getSourceMgr());
+      llvm::outs() << "\t";
+      body->getEndLoc().print(llvm::outs(), TheRewriter.getSourceMgr());
+      llvm::outs() << "\t";
+      llvm::outs() << "FunctionEpilogue";
+      llvm::outs() << "\n";
+    }
+    return true;
+  }
 
   bool VisitVarDecl(VarDecl *s) {
     // VarDecl has computation only when it has an initialiser

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,8 +92,6 @@ VAArgExpr
   v(CXXPseudoDestructorExpr) \
   v(CXXScalarValueInitExpr) \
   v(CXXTypeidExpr) \
-  v(CallExpr) \
-  v(CXXMemberCallExpr) \
   /* v(CastExpr) */ /* too many artificial instances of this */ \
   v(ChooseExpr) \
   v(GenericSelectionExpr) \
@@ -169,6 +167,16 @@ VAArgExpr
   }
 
   // Some nodes require customised handling depending on the data they contain
+
+  bool VisitCallExpr(CallExpr *s) {
+    if (const auto *callee = s->getCallee()) {
+      VISITOR_METHOD_PRINT(CallExpr.Callee, callee)
+    }
+    // Arguments shouldn't be added at this level, as they may have a whole tree
+    // of multi-line computation, so we instead inspect them further by
+    // recursion
+    return true;
+  }
 
   bool VisitFunctionDecl(FunctionDecl *s) {
     // We want to mark the opening and closing braces as having computation

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,9 +151,9 @@ VAArgExpr
   }
 
   bool VisitVarDecl(VarDecl *s) {
-    // VarDecl has computation only when it has an initialiser
+    // VarDecl has computation only for locals with an initialiser
     // TODO: Check C++ default initialisation cases
-    if (!s->hasInit())
+    if (!s->isLocalVarDecl() || !s->hasInit())
       return true;
     VISITOR_METHOD_INNER(VarDecl)
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,6 +99,7 @@ VAArgExpr
   v(GenericSelectionExpr) \
   v(LambdaExpr) \
   v(MaterializeTemporaryExpr) \
+  v(MemberExpr) \
   v(OpaqueValueExpr) \
   v(PseudoObjectExpr) \
   v(UnaryOperator) \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,6 +104,9 @@ VAArgExpr
   v(PseudoObjectExpr) \
   v(UnaryOperator) \
   v(VAArgExpr) \
+  v(BreakStmt) \
+  v(ContinueStmt) \
+  v(GotoStmt) \
   v(ReturnStmt)
 
 #define VISITOR_METHOD_INNER(tok) \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ public:
   v(CXXTypeidExpr) \
   /* v(CastExpr) */ /* too many artificial instances of this */ \
   v(ChooseExpr) \
+  v(DeclRefExpr) /* may be too general, requires excluding constants */ \
   v(GenericSelectionExpr) \
   v(LambdaExpr) \
   v(MaterializeTemporaryExpr) \
@@ -152,6 +153,11 @@ public:
     // Arguments shouldn't be added at this level, as they may have a whole tree
     // of multi-line computation, so we instead inspect them further by
     // recursion
+    return true;
+  }
+
+  bool TraverseConstantExpr(ConstantExpr *s) {
+    // Skip constant expressions (e.g. case statements)
     return true;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,29 +55,6 @@ public:
      So let's focus on those... what kinds of expression are there? Expr is the base.
      Problem: the taxonomy of statements/expressions is liable to change
      across clang versions.
-     The following comes from version 8 (StmtNodes.inc) and is my filter on "might do computation".
-ArraySubscriptExpr
-BinaryOperator      (no 'Expr')
-CXXConstructExpr    (CXXTemporaryObjectExpr is a subclass)
-CXXDefaultArgExpr
-CXXFoldExpr         what is this?
-CXXInheritedCtorInitExpr
-CXXNewExpr
-CXXPseudoDestructorExpr
-CXXScalarValueInitExpr
-CXXTypeidExpr
-CallExpr
-CXXMemberCallExpr
-CastExpr            many subclasses, but even C-style cast in C++ might do pointer adjustment
-ChooseExpr
-FullExpr            what is this?
-GenericSelectionExpr  what is this?
-LambdaExpr
-MaterializeTemporaryExpr  what is this?
-OpaqueValueExpr           what is this?
-PseudoObjectExpr          what is this?
-UnaryOperator
-VAArgExpr
 
      Let's use a macroised list to generate our visitors
    */

--- a/test/var-decl/Makefile
+++ b/test/var-decl/Makefile
@@ -1,0 +1,1 @@
+include ../rules.mk

--- a/test/var-decl/var-decl.c
+++ b/test/var-decl/var-decl.c
@@ -1,0 +1,5 @@
+int main(int argc, char **argv)
+{
+  int a;     // no computation
+  int b = 2; // has computation via initialiser
+}


### PR DESCRIPTION
This includes various tweaks which go beyond a simple list of node types to more precisely select expressions which have computation esp. according to Clang's O0 line table output.

There are still various known issues that remain, so this just groups together a first batch of tweaks. See each commit for a tad more context on what has changed here.